### PR TITLE
Add failure on non-windows systems

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -24,6 +24,10 @@ class msuac (
   $prompt  = 'consentprompt',
 ) {
 
+  if $::operatingsystem != 'Windows' {
+    fail ("Class[msuac] can only be applied to Windows systems. It cannot be used on \"${::operatingsystem}.\"")
+  }
+
   validate_bool($enabled)
   validate_re($prompt, '^(consentprompt|authprompt|disabled)$')
 


### PR DESCRIPTION
Without this commit, this class could become part of a catalog for a
system that is not a windows machine. This catalog could then be
partially applied but would fail on the resources within this class.

This commit adds a check that will fail catalog compilation in the event
this class is applied to a non-windows machine.
